### PR TITLE
Implement core layout and API services

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "angular-example",
       "version": "0.0.0",
       "dependencies": {
+        "axios": "^1.7.7",
         "@angular/cdk": "^19.2.19",
         "@angular/common": "^19.2.0",
         "@angular/compiler": "^19.2.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "private": true,
   "dependencies": {
+    "axios": "^1.7.7",
     "@angular/cdk": "^19.2.19",
     "@angular/common": "^19.2.0",
     "@angular/compiler": "^19.2.0",

--- a/src/app/core/components/footer/footer.component.html
+++ b/src/app/core/components/footer/footer.component.html
@@ -1,3 +1,12 @@
-<footer class="footer">
-  <p>Footer placeholder content</p>
-</footer>
+<mat-toolbar color="primary" class="app-footer">
+  <span>© {{ year }} Topcoder. All rights reserved.</span>
+  <span class="spacer"></span>
+  <a
+    class="external-link"
+    href="https://www.topcoder.com"
+    target="_blank"
+    rel="noopener noreferrer"
+  >
+    topcoder.com
+  </a>
+</mat-toolbar>

--- a/src/app/core/components/footer/footer.component.scss
+++ b/src/app/core/components/footer/footer.component.scss
@@ -1,3 +1,13 @@
-.footer {
-  text-align: center;
+.app-footer {
+  padding: 0 1.5rem;
+  font-size: 0.875rem;
+  background-color: rgb(0, 157, 208);
+
+  .spacer {
+    flex: 1;
+  }
+
+  .external-link {
+    color: inherit;
+  }
 }

--- a/src/app/core/components/footer/footer.component.ts
+++ b/src/app/core/components/footer/footer.component.ts
@@ -3,6 +3,8 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'app-footer',
   templateUrl: './footer.component.html',
-  styleUrls: ['./footer.component.scss'],
+  styleUrls: ['./footer.component.scss']
 })
-export class FooterComponent {}
+export class FooterComponent {
+  readonly year = new Date().getFullYear();
+}

--- a/src/app/core/components/header/header.component.html
+++ b/src/app/core/components/header/header.component.html
@@ -1,3 +1,5 @@
-<header class="header">
-  <h1>Header placeholder</h1>
-</header>
+<mat-toolbar color="primary" class="app-toolbar">
+  <img src="assets/tco-logo.svg" alt="TCO logo" class="tco-logo" />
+  <span class="toolbar-title">Bidding Platform</span>
+  <span class="spacer"></span>
+</mat-toolbar>

--- a/src/app/core/components/header/header.component.scss
+++ b/src/app/core/components/header/header.component.scss
@@ -1,3 +1,22 @@
-.header {
-  text-align: center;
+.app-toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  padding: 0 16px;
+  background-color: rgb(0, 157, 208);
+}
+
+.toolbar-title {
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.spacer {
+  flex: 1;
+}
+
+.tco-logo {
+  height: 2.5rem;
+  width: auto;
+  height: -webkit-fill-available;
 }

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -1,9 +1,17 @@
+import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
 
-/**
- * CoreModule serves as a placeholder for singleton services and core components.
- */
+import { FooterComponent } from './components/footer/footer.component';
+import { HeaderComponent } from './components/header/header.component';
+import { API_BASE_URL } from './services/api.base';
+import { MaterialModule } from '../shared/material/material.module';
+import { environment } from '../../environments/environment';
+
 @NgModule({
-  providers: [],
+  declarations: [HeaderComponent, FooterComponent],
+  imports: [CommonModule, RouterModule, MaterialModule],
+  exports: [HeaderComponent, FooterComponent],
+  providers: [{ provide: API_BASE_URL, useValue: environment.apiBaseUrl }]
 })
 export class CoreModule {}

--- a/src/app/core/services/api.base.ts
+++ b/src/app/core/services/api.base.ts
@@ -1,6 +1,74 @@
-/**
- * Base API service placeholder for shared HTTP configuration.
- */
-export abstract class ApiBase {
-  protected readonly baseUrl = '/api';
+import { Inject, Injectable, InjectionToken, Optional } from '@angular/core';
+import axios, {
+  AxiosInstance,
+  AxiosRequestConfig,
+  AxiosResponse,
+  InternalAxiosRequestConfig
+} from 'axios';
+import { from, Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+
+export const API_BASE_URL = new InjectionToken<string>('API_BASE_URL');
+const DEFAULT_API_BASE_URL = environment.apiBaseUrl;
+
+type RequestConfig = AxiosRequestConfig;
+
+@Injectable({ providedIn: 'root' })
+export class ApiService {
+  private readonly client: AxiosInstance;
+
+  constructor(@Optional() @Inject(API_BASE_URL) baseUrl?: string) {
+    this.client = axios.create({
+      baseURL: baseUrl ?? DEFAULT_API_BASE_URL,
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    });
+
+    this.client.interceptors.response.use(
+      (response) => response,
+      (error) => Promise.reject(this.normalizeError(error))
+    );
+  }
+
+  get<T>(url: string, config?: RequestConfig): Observable<T> {
+    return this.send<T>({ ...config, method: 'get', url });
+  }
+
+  post<T>(url: string, data?: unknown, config?: RequestConfig): Observable<T> {
+    return this.send<T>({ ...config, method: 'post', url, data });
+  }
+
+  put<T>(url: string, data?: unknown, config?: RequestConfig): Observable<T> {
+    return this.send<T>({ ...config, method: 'put', url, data });
+  }
+
+  patch<T>(url: string, data?: unknown, config?: RequestConfig): Observable<T> {
+    return this.send<T>({ ...config, method: 'patch', url, data });
+  }
+
+  delete<T>(url: string, config?: RequestConfig): Observable<T> {
+    return this.send<T>({ ...config, method: 'delete', url });
+  }
+
+  private send<T>(config: RequestConfig): Observable<T> {
+    return from(
+      this.client
+        .request<T>(config as InternalAxiosRequestConfig)
+        .then((response: AxiosResponse<T>) => response.data)
+    );
+  }
+
+  private normalizeError(error: unknown): Error {
+    if (axios.isAxiosError(error)) {
+      const message = (error.response?.data as { message?: string } | undefined)?.message ?? error.message;
+      return new Error(message);
+    }
+
+    if (error instanceof Error) {
+      return error;
+    }
+
+    return new Error('An unexpected error occurred.');
+  }
 }

--- a/src/app/core/services/api.service.ts
+++ b/src/app/core/services/api.service.ts
@@ -1,12 +1,30 @@
 import { Injectable } from '@angular/core';
-import { ApiBase } from './api.base';
+import { Observable } from 'rxjs';
+
+import { BiddingReport } from '../../features/home/reports/bidding-report.interface';
+import { ApiService } from './api.base';
 
 @Injectable({ providedIn: 'root' })
-export class ApiService extends ApiBase {
-  /**
-   * Placeholder method that represents a future API call.
-   */
-  fetchPlaceholder(): void {
-    // Implementation will be added with real API calls.
+export class ApiEndpointService {
+  constructor(private readonly api: ApiService) {}
+
+  getBiddingReports(filters?: { month?: number | null; year?: number | null }): Observable<BiddingReport[]> {
+    const month = filters?.month ?? null;
+    const year = filters?.year ?? null;
+
+    if (month !== null && year !== null) {
+      const params = new URLSearchParams({
+        month: String(month),
+        year: String(year)
+      });
+
+      return this.api.get<BiddingReport[]>(`/BiddingReports/by-month?${params.toString()}`);
+    }
+
+    return this.api.get<BiddingReport[]>('/BiddingReports');
+  }
+
+  getBiddingReport(reportId: number): Observable<BiddingReport> {
+    return this.api.get<BiddingReport>(`/BiddingReports/${reportId}`);
   }
 }

--- a/src/app/features/home/reports/bidding-report.interface.ts
+++ b/src/app/features/home/reports/bidding-report.interface.ts
@@ -1,5 +1,5 @@
 export interface BiddingReport {
-  id: string;
+  id: number;
   title: string;
   createdOn: string;
 }

--- a/src/app/shared/material/material.module.ts
+++ b/src/app/shared/material/material.module.ts
@@ -1,9 +1,9 @@
 import { NgModule } from '@angular/core';
+import { MatToolbarModule } from '@angular/material/toolbar';
 
-/**
- * Placeholder Material module for future Angular Material imports.
- */
+const MATERIAL_MODULES = [MatToolbarModule];
+
 @NgModule({
-  exports: [],
+  exports: MATERIAL_MODULES
 })
 export class MaterialModule {}

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,3 +1,4 @@
 export const environment = {
   production: false,
+  apiBaseUrl: '/api'
 };


### PR DESCRIPTION
## Summary
- replace the placeholder header and footer with Angular Material toolbars and branding content
- configure the core module and shared Material module to expose the toolbar components and API base URL
- implement the axios-powered API service layer and bidding report endpoints plus supporting environment types

## Testing
- npm install *(fails: 403 Forbidden when reaching the npm registry in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5f37d4030832f94124e1231d3a3d2